### PR TITLE
뒤로가기 아이콘 수정

### DIFF
--- a/components/ui/TossHeader.tsx
+++ b/components/ui/TossHeader.tsx
@@ -1,4 +1,5 @@
 import { TossColors, TossSpacing } from '@/constants/toss-design-system';
+import { Ionicons } from '@expo/vector-icons';
 import React from 'react';
 import {
   StyleSheet,
@@ -39,8 +40,7 @@ export function TossHeader({
       <View style={styles.leftSection}>
         {showBackButton ? (
           <TouchableOpacity onPress={onBackPress} style={styles.backButton}>
-            {/* Back icon */}
-            <TossText style={styles.backIcon}>←</TossText>
+            <Ionicons name="chevron-back" size={24} color={TossColors.textPrimary} />
           </TouchableOpacity>
         ) : leftIcon ? (
           <TouchableOpacity onPress={onLeftPress} style={styles.iconButton}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * TossHeader의 뒤로 가기 버튼 아이콘을 텍스트 기반 화살표에서 표준 아이콘으로 개선했습니다. 사용자 경험 및 시각적 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->